### PR TITLE
add local database for favourite radio stations

### DIFF
--- a/.idea/dictionaries/ai.xml
+++ b/.idea/dictionaries/ai.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="ai" />
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidLintTypos" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/airsyad/radiojuicer/data/RadioStation.kt
+++ b/app/src/main/java/com/airsyad/radiojuicer/data/RadioStation.kt
@@ -3,7 +3,5 @@ package com.airsyad.radiojuicer.data
 data class RadioStation(
     val stationUiid: String,
     val name: String,
-    val logo_url: String,
-    val country_name: String,
-    val country_code: String
+    val logoUrl: String
 )

--- a/app/src/main/java/com/airsyad/radiojuicer/data/local/FavouriteRadioStation.kt
+++ b/app/src/main/java/com/airsyad/radiojuicer/data/local/FavouriteRadioStation.kt
@@ -1,0 +1,11 @@
+package com.airsyad.radiojuicer.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favourite_radio_station")
+data class FavouriteRadioStation(
+    @PrimaryKey val stationUiid: String,
+    val name: String,
+    val logoUrl: String
+)

--- a/app/src/main/java/com/airsyad/radiojuicer/data/local/FavouriteRadioStationDao.kt
+++ b/app/src/main/java/com/airsyad/radiojuicer/data/local/FavouriteRadioStationDao.kt
@@ -1,0 +1,18 @@
+package com.airsyad.radiojuicer.data.local
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavouriteRadioStationDao {
+    @Query("SELECT * FROM favourite_radio_station")
+    fun getAll(): Flow<List<FavouriteRadioStation>>
+
+    @Upsert
+    fun upsert(favouriteRadioStation: FavouriteRadioStation)
+
+    @Query("DELETE FROM favourite_radio_station")
+    fun deleteAll()
+}

--- a/app/src/main/java/com/airsyad/radiojuicer/data/local/RadioStationDatabase.kt
+++ b/app/src/main/java/com/airsyad/radiojuicer/data/local/RadioStationDatabase.kt
@@ -1,0 +1,13 @@
+package com.airsyad.radiojuicer.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [FavouriteRadioStation::class],
+    exportSchema = false,
+    version = 1
+)
+abstract class RadioStationDatabase : RoomDatabase() {
+    abstract fun favouriteRadioStationDao(): FavouriteRadioStationDao
+}


### PR DESCRIPTION
add:
- `FavouriteRadioStation` class as entity to save favourite radio station into local database using Room
- `FavouriteRadioStationDao` interface as the DAO for `FavouriteRadioStation`
- `RadioStationDatabase` class as the database that will be used to save `FavouriteRadioStation` and other entities that might be needed in the future